### PR TITLE
Fix for ex02 test

### DIFF
--- a/ex02/test_ex02.sh
+++ b/ex02/test_ex02.sh
@@ -21,7 +21,7 @@
 }
 
 
-@test "2 existing paths" {
+@test "Another 2 existing paths" {
   run bash ex02.sh "FOLDER STR"
   [ "$status" -eq 0 ]
   [ "$output" = $'FOLDER\n./resources/FOLDER:\n./resources/FOLDER/STR:\nSTR\n./resources/FOLDER/STR:' ]


### PR DESCRIPTION
Running ex02 test gives you a warning:
`bats warning: duplicate test name(s) in test_ex02.sh: test_2_existing_paths`
